### PR TITLE
docs: document gpt init step

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,22 @@ overlay use -pr ./gpt
 
 ### Step 3.
 
+Initialize the cross.stream command that performs the actual LLM call. This appends the command to
+your event stream so later `gpt` invocations can use it:
+
+```nushell
+gpt init
+```
+
+### Step 4.
+
 Enable your preferred provider. This stores the API key for later use:
 
 ```nushell
 gpt provider enable
 ```
 
-### Step 4.
+### Step 5.
 
 Set up a `milli` alias for a lightweight model (try OpenAI's `gpt-4.1-mini` or Anthropic's
 `claude-3-5-haiku-20241022`):
@@ -77,7 +86,7 @@ Set up a `milli` alias for a lightweight model (try OpenAI's `gpt-4.1-mini` or A
 gpt provider ptr milli --set
 ```
 
-### Step 5.
+### Step 6.
 
 Give it a spin:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,16 @@ It really is easy from here.
 overlay use -pr ./gpt
 ```
 
-## Step 3: Configure a provider
+## Step 3: Initialize the command
+
+Initialize the cross.stream command that performs the actual LLM call. This appends the command to
+your event stream so later `gpt` invocations can use it:
+
+```nushell
+gpt init
+```
+
+## Step 4: Configure a provider
 
 Enable your preferred provider. This stores the API key for later use:
 
@@ -42,7 +51,7 @@ gpt provider enable
 
 For detailed provider configuration, see [Configure Providers](how-to/configure-providers.md).
 
-## Step 4: Set up a model alias
+## Step 5: Set up a model alias
 
 Set up a `milli` alias for a lightweight model (try OpenAI's `gpt-4.1-mini` or Anthropic's
 `claude-3-5-haiku-20241022`):
@@ -51,7 +60,7 @@ Set up a `milli` alias for a lightweight model (try OpenAI's `gpt-4.1-mini` or A
 gpt provider ptr milli --set
 ```
 
-## Step 5: Test your setup
+## Step 6: Test your setup
 
 Give it a spin:
 


### PR DESCRIPTION
## Summary
- note that `gpt init` must be run after loading the module
- clarify that `gpt init` appends the LLM command to the event stream before provider setup

## Testing
- `nu tests/run.nu` *(fails: command not found: nu)*
- `cargo install nu` *(fails: failed to download from `https://index.crates.io/config.json`, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896211b536c832cb8e9e093caa34f47