### PR TITLE
use `after` not `last-id`

### DIFF
--- a/gpt/mcp.nu
+++ b/gpt/mcp.nu
@@ -7,7 +7,7 @@ export def "register" [name: string command: string] {
   }" | .append $"mcp.($name).spawn"
 
   # Wait for the server to be ready
-  .cat -f --last-id $spawn_frame.id
+  .cat -f --after $spawn_frame.id
   | where topic == $"mcp.($name).ready"
   | first
 }
@@ -48,7 +48,7 @@ export def "call" [name: string] {
   let command = $in
   let frame = $command | to json -r | $in + "\n" | .append $"mcp.($name).send" --meta {id: $command.id}
   let res = (
-    .cat -f --last-id $frame.id
+    .cat -f --after $frame.id
     | where topic == $"mcp.($name).recv"
     | each { .cas $in.hash | from json }
     | where { $in.id? == $command.id }

--- a/gpt/mod.nu
+++ b/gpt/mod.nu
@@ -232,7 +232,7 @@ export def process-turn [turn: record] {
 
 export def call [turn_id: string preview?: closure] {
   let req = .append gpt.call --meta {continues: $turn_id}
-  let res = .cat -f --last-id $req.id
+  let res = .cat -f --after $req.id
   | conditional-pipe ($preview | is-not-empty) {
     tee {
       where {|frame|

--- a/xs.nu
+++ b/xs.nu
@@ -66,7 +66,7 @@ def _cat [options: record] {
     (if ($options | get tail? | default false) { "--tail" })
     (if ($options | get all? | default false) { "--all" })
 
-    (if $options.last_id? != null { ["--last-id" $options.last_id] })
+    (if $options.after? != null { ["--after" $options.after] })
 
     (if $options.limit? != null { ["--limit" $options.limit] })
     (if $options.pulse? != null { ["--pulse" $options.pulse] })
@@ -82,7 +82,7 @@ export def .cat [
   --pulse (-p): int # specifies the interval (in milliseconds) to receive a synthetic "xs.pulse" event
   --tail (-t) # begin long after the end of the stream
   --detail (-d) # include all frame fields in the output
-  --last-id (-l): string
+  --after (-A): string
   --limit: int
   --context (-c): string # the context to read from
   --all (-a) # cat across all contexts
@@ -92,7 +92,7 @@ export def .cat [
     follow: $follow
     pulse: $pulse
     tail: $tail
-    last_id: $last_id
+    after: $after
     limit: $limit
     context: (if not $all { (xs-context $context (metadata $context).span) })
     all: $all


### PR DESCRIPTION
Small pr to update usage of `last-id` to `after` following docs https://cablehead.github.io/xs/reference/cli/#cat